### PR TITLE
s()  called inside mgcv::gam

### DIFF
--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -8,7 +8,7 @@
 #' @import igraph
 #' @importFrom irlba irlba
 #' @import pcaMethods
-#' @importFrom mgcv gam
+#' @importFrom mgcv gam s
 #' @importFrom parallel mclapply
 # @importFrom scde pagoda.reduce.loading.redundancy pagoda.reduce.redundancy
 #' @importFrom RMTstat WishartMaxPar

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -191,7 +191,9 @@ Pagoda2 <- setRefClass(
       } else {
         if(verbose) cat(" using gam ")
         require(mgcv)
-        m <- mgcv::gam(v ~ s(m, k = gam.k), data = df[vi,])
+        formul <- as.formula(v~s(m,k=gam.k))
+        environment(formul) <- asNamespace("mgcv")
+        m <- mgcv::gam(formula=formul, data = df[vi,])
       }
       df$res <- -Inf;  df$res[vi] <- resid(m,type='response')
       n.obs <- df$nobs; #diff(counts@p)

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -191,7 +191,7 @@ Pagoda2 <- setRefClass(
       } else {
         if(verbose) cat(" using gam ")
         require(mgcv)
-        m <- mgcv::gam(v ~ s(m, k = gam.k), data = df[vi,])
+        m <- mgcv::gam(v ~ mgcv::s(m, k = gam.k), data = df[vi,])
       }
       df$res <- -Inf;  df$res[vi] <- resid(m,type='response')
       n.obs <- df$nobs; #diff(counts@p)

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -23,7 +23,7 @@ Pagoda2 <- setRefClass(
   "Pagoda2",
   fields=c('counts','clusters','graphs','reductions','embeddings','diffgenes','pathways','n.cores','misc','batch','modelType','verbose','depth','batchNorm','mat'),
   methods = list(
-    initialize=function(x, ..., modelType='plain',batchNorm='glm',n.cores=30,verbose=TRUE,min.cells.per.gene=30,trim=round(min.cells.per.gene/2),lib.sizes=NULL,log.scale=FALSE) {
+    initialize=function(x, ..., modelType='plain',batchNorm='glm',n.cores=parallel::detectCores(),verbose=TRUE,min.cells.per.gene=30,trim=round(min.cells.per.gene/2),lib.sizes=NULL,log.scale=FALSE) {
       # # init all the output lists
       embeddings <<- list();
       graphs <<- list();

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -192,7 +192,9 @@ Pagoda2 <- setRefClass(
         if(verbose) cat(" using gam ")
         require(mgcv)
         formul <- as.formula(v~s(m,k=gam.k))
-        environment(formul) <- asNamespace("mgcv")
+        eformul <- new.env(parent=as.environment("package:mgcv"))
+        assign("gam.k",gam.k,envir=eformul)
+        environment(formul) <- eformul
         m <- mgcv::gam(formula=formul, data = df[vi,])
       }
       df$res <- -Inf;  df$res[vi] <- resid(m,type='response')

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -191,7 +191,8 @@ Pagoda2 <- setRefClass(
       } else {
         if(verbose) cat(" using gam ")
         require(mgcv)
-        m <- mgcv::gam(v ~ mgcv::s(m, k = gam.k), data = df[vi,])
+        s <- mgcv::s
+        m <- mgcv::gam(v ~ s(m, k = gam.k), data = df[vi,])
       }
       df$res <- -Inf;  df$res[vi] <- resid(m,type='response')
       n.obs <- df$nobs; #diff(counts@p)

--- a/R/sparseclust.r
+++ b/R/sparseclust.r
@@ -191,7 +191,6 @@ Pagoda2 <- setRefClass(
       } else {
         if(verbose) cat(" using gam ")
         require(mgcv)
-        s <- mgcv::s
         m <- mgcv::gam(v ~ s(m, k = gam.k), data = df[vi,])
       }
       df$res <- -Inf;  df$res[vi] <- resid(m,type='response')

--- a/inst/include/pagoda2.h
+++ b/inst/include/pagoda2.h
@@ -26,6 +26,8 @@
 #include "methodfactory.h"
 #include "spacefactory.h"
 #include "ztimer.h"
+#include "lshkit.h"
+
 
 using namespace std;
 using namespace Rcpp;

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
-PKG_CXXFLAGS=-I"$(NMSLIB_PATH)/similarity_search/include" -I"../inst/include" -std=c++11
-PKG_LIBS=-L/usr/lib/ -L$(NMSLIB_PATH)/similarity_search/release -lNonMetricSpaceLib -lgsl -lgslcblas -llshkit -lpthread -fopenmp -lstdc++ `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_CXXFLAGS=-I"$(NMSLIB_PATH)/similarity_search/include" -I"$(NMSLIB_PATH)/similarity_search/lshkit/include" -I"../inst/include" -std=c++11
+PKG_LIBS=-L/usr/lib/ -L$(NMSLIB_PATH)/similarity_search/release  -lNonMetricSpaceLib -lgsl -lgslcblas -lpthread -fopenmp -lstdc++ `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -304,3 +304,34 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+
+static const R_CallMethodDef CallEntries[] = {
+    {"pagoda2_non0LogColLmS", (DL_FUNC) &pagoda2_non0LogColLmS, 4},
+    {"pagoda2_colMeanVarS", (DL_FUNC) &pagoda2_colMeanVarS, 2},
+    {"pagoda2_colSumByFac", (DL_FUNC) &pagoda2_colSumByFac, 2},
+    {"pagoda2_inplaceColMult", (DL_FUNC) &pagoda2_inplaceColMult, 3},
+    {"pagoda2_inplaceWinsorizeSparseCols", (DL_FUNC) &pagoda2_inplaceWinsorizeSparseCols, 2},
+    {"pagoda2_jsDist", (DL_FUNC) &pagoda2_jsDist, 1},
+    {"pagoda2_orderColumnRows", (DL_FUNC) &pagoda2_orderColumnRows, 2},
+    {"pagoda2_smatColVecCorr", (DL_FUNC) &pagoda2_smatColVecCorr, 3},
+    {"pagoda2_arma_mat_cor", (DL_FUNC) &pagoda2_arma_mat_cor, 1},
+    {"pagoda2_hnswKnn", (DL_FUNC) &pagoda2_hnswKnn, 4},
+    {"pagoda2_hnswKnn2", (DL_FUNC) &pagoda2_hnswKnn2, 8},
+    {"pagoda2_hnswKnnJS", (DL_FUNC) &pagoda2_hnswKnnJS, 7},
+    {"pagoda2_hnswKnnLp", (DL_FUNC) &pagoda2_hnswKnnLp, 9},
+    {"pagoda2_hnswKnn3test", (DL_FUNC) &pagoda2_hnswKnn3test, 10},
+    {"pagoda2_matWCorr", (DL_FUNC) &pagoda2_matWCorr, 2},
+    {"pagoda2_winsorizeMatrix", (DL_FUNC) &pagoda2_winsorizeMatrix, 2},
+    {"pagoda2_plSemicompleteCor2", (DL_FUNC) &pagoda2_plSemicompleteCor2, 1},
+    {"pagoda2_avg_rank", (DL_FUNC) &pagoda2_avg_rank, 1},
+    {"pagoda2_sparse_matrix_column_ranks", (DL_FUNC) &pagoda2_sparse_matrix_column_ranks, 1},
+    {"pagoda2_nearbyPointsGreedyCluster", (DL_FUNC) &pagoda2_nearbyPointsGreedyCluster, 2},
+    {"pagoda2_closestNPointsToSegments", (DL_FUNC) &pagoda2_closestNPointsToSegments, 5},
+    {"pagoda2_closestNSegmentsToPoints", (DL_FUNC) &pagoda2_closestNSegmentsToPoints, 5},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_pagoda2(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/nsmlib.cpp
+++ b/src/nsmlib.cpp
@@ -548,4 +548,3 @@ DataFrame hnswKnn3test(NumericMatrix m, int k=5, int multiplex=1, int nqueries=1
                            _["e"] = endV,
                            _["d"] = distV);
 }
-


### PR DESCRIPTION
I tried to find a solution for a small namespace problem within the function mgcv::gam() in the Variance adjustment. 
If the function s() is defined by another package or by the user in the global environment, adjustVariance will not work.
As it is not possible to call mgcv::gam(v~mgcv::s(m, k=gam.k))  I suggest this solution. 