### PR TITLE
Update Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -16,7 +16,7 @@ sublibs: sublibraries
 
 sublibraries: 
 	@for d in $(SUBDIRS); do \
-          (cd $${d} && CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" MAKE="$(MAKE) -f \"$(MkInclude)\" -f Makefile" $(MAKE) -f "$(MkInclude)" -f Makefile lib) || exit 1; \
+          (cd $${d} && CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" MAKE="$(MAKE) -f \"$(MkInclude)\" -f Makefile" $(MAKE) CXX="$(CXX11)" -f "$(MkInclude)" -f Makefile lib) || exit 1; \
         done
 
 clean: subclean


### PR DESCRIPTION
Fix the make instructions to use the C++ compiler that is used by R for the other cpp files and specified in the .R\Makevars. 
This fixes the fopenmp issue for Macs with the clang++ 4.0 installed.